### PR TITLE
feat: validate layers cache type only redis

### DIFF
--- a/src/common/validations.ts
+++ b/src/common/validations.ts
@@ -27,6 +27,6 @@ export const isRedisCache = (cacheName: string, mapproxyConfigYaml: string): boo
   const mapproxyConfigJson = load(mapproxyConfigYaml) as IMapProxyConfig;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const cache = mapproxyConfigJson.caches[cacheName].cache as ICacheSource;
-  const isValidRedisCache = cache.type === CacheType.REDIS;
-  return isValidRedisCache;
+  const isRedisCache = cache.type === CacheType.REDIS;
+  return isRedisCache;
 };

--- a/src/common/validations.ts
+++ b/src/common/validations.ts
@@ -1,5 +1,8 @@
 import { promises, constants } from 'node:fs';
 import moment from 'moment';
+import { load } from 'js-yaml';
+import { ICacheSource, IMapProxyConfig } from './interfaces';
+import { CacheType } from './enums';
 
 export const zoomComparison = (fromZoom: number, toZoom: number): boolean => {
   const valid = fromZoom <= toZoom;
@@ -18,4 +21,12 @@ export const fileExists = async (filePath: string): Promise<boolean> => {
 export const isValidDateFormat = (dateString: string): boolean => {
   const isValidDateFormat = moment(dateString, moment.ISO_8601, true).isValid();
   return isValidDateFormat;
+};
+
+export const isRedisCache = (cacheName: string, mapproxyConfigYaml: string): boolean => {
+  const mapproxyConfigJson = load(mapproxyConfigYaml) as IMapProxyConfig;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const cache = mapproxyConfigJson.caches[cacheName].cache as ICacheSource;
+  const isValidRedisCache = cache.type === CacheType.REDIS;
+  return isValidRedisCache;
 };

--- a/src/mapproxyUtils/mapproxySeed.ts
+++ b/src/mapproxyUtils/mapproxySeed.ts
@@ -61,7 +61,7 @@ export class MapproxySeed {
       if (!isRedisCache(task.layerId, mapproxyConfig as string)) {
         throw new Error(`Cache type should be of type Redis`);
       }
-      
+
       await this.writeGeojsonTxtFile(this.geometryCoverageFilePath, JSON.stringify(task.geometry), jobId, taskId);
       await this.createSeedYamlFile(task, jobId, taskId);
       await this.executeSeed(task, jobId, taskId);

--- a/tests/mockData/mockBadConfig.yaml
+++ b/tests/mockData/mockBadConfig.yaml
@@ -31,7 +31,7 @@ caches:
     minimize_meta_request: true
   test:
     cache:
-      type: redis
+      type: file
       directory: /testId2/VectorBest/
       directory_layout: tms
     grids:

--- a/tests/unit/mapproxyUtils/mapproxySeedFailOnCliCrash.spec.ts
+++ b/tests/unit/mapproxyUtils/mapproxySeedFailOnCliCrash.spec.ts
@@ -46,7 +46,7 @@ describe('#MapproxySeed', () => {
   });
 
   describe('#HandleSeedTasks', () => {
-    it.only('running single seed task with bad command - internal process error', async function () {
+    it('running single seed task with bad command - internal process error', async function () {
       const task = getTask();
       const mockYamlFile = 'tests/mockData/mockConfig.yaml';
       const yamlContent = readFileSync(mockYamlFile, { encoding: 'utf8' });

--- a/tests/unit/mapproxyUtils/mapproxySeedFailures.spec.ts
+++ b/tests/unit/mapproxyUtils/mapproxySeedFailures.spec.ts
@@ -249,9 +249,8 @@ describe('#MapproxySeed', () => {
         };
 
         await expect(action).rejects.toThrow(`failed seed for job of test with reason: Cache type should be of type Redis`);
-        expect(writeMapproxyYamlSpy).toHaveBeenCalledTimes(1);
-        expect(writeFileStub).toHaveBeenCalledTimes(1);
-        expect(writeFileStub).toHaveBeenNthCalledWith(1, configMock.get('mapproxy.mapproxyYamlDir'), yamlContent, 'utf8');
+        expect(writeMapproxyYamlSpy).toHaveBeenCalledTimes(0);
+        expect(writeFileStub).toHaveBeenCalledTimes(0);
       });
 
       it('Failed on not exists file (geometryCoverageFileJson)', async function () {

--- a/tests/unit/mapproxyUtils/mapproxySeedFailures.spec.ts
+++ b/tests/unit/mapproxyUtils/mapproxySeedFailures.spec.ts
@@ -234,6 +234,26 @@ describe('#MapproxySeed', () => {
         expect(accessStub).toHaveBeenCalledTimes(1);
       });
 
+      it('Failed on not valid cache type on mapproxyYaml (not redis)', async function () {
+        const task = getTask();
+        const mockYamlFile = 'tests/mockData/mockBadConfig.yaml';
+        const yamlContent = readFileSync(mockYamlFile, { encoding: 'utf8' });
+        nock(mapproxyTestUrl).get(`/config`).reply(200, yamlContent);
+        const writeMapproxyYamlSpy = jest.spyOn(MapproxySeed.prototype as unknown as { writeMapproxyYaml: jest.Mock }, 'writeMapproxyYaml');
+
+        writeFileStub = jest.spyOn(fsp, 'writeFile').mockImplementation(async () => undefined);
+        accessStub = jest.spyOn(fsp, 'access').mockImplementation(async () => undefined);
+
+        const action = async () => {
+          await mapproxySeed.runSeed(task.parameters.seedTasks[0], task.jobId, task.id);
+        };
+
+        await expect(action).rejects.toThrow(`failed seed for job of test with reason: Cache type should be of type Redis`);
+        expect(writeMapproxyYamlSpy).toHaveBeenCalledTimes(1);
+        expect(writeFileStub).toHaveBeenCalledTimes(1);
+        expect(writeFileStub).toHaveBeenNthCalledWith(1, configMock.get('mapproxy.mapproxyYamlDir'), yamlContent, 'utf8');
+      });
+
       it('Failed on not exists file (geometryCoverageFileJson)', async function () {
         const task = getTask();
         const mockYamlFile = 'tests/mockData/mockConfig.yaml';


### PR DESCRIPTION
Cache seeder support only caches of type redis to execute seeding

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                       |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |

To prevent seeding on other sources (for example s3) that considered also as cache on our configuration yaml, the service will validate cache type and check if redis, if not will throw failure