### PR TITLE
feat: auth support patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN npm ci --only=production
 
 RUN apt-get update || : && apt-get install python3 -y
 RUN apt install dumb-init
+RUN apt-get install python3-pil -y
 RUN apt-get install -y procps && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=node:node --from=mid /usr/src/app/dist .

--- a/docker/patch/redis.py
+++ b/docker/patch/redis.py
@@ -47,7 +47,7 @@ class RedisCache(TileCacheBase):
         self.prefix = prefix
         self.lock_cache_id = 'redis-' + hashlib.md5((host + str(port) + prefix + str(db)).encode('utf-8')).hexdigest()
         self.ttl = ttl
-        self.r = redis.StrictRedis(host=host, port=port, db=db, password=password,username=user)
+        self.r = redis.StrictRedis(host=host, port=port, db=db, password=password, username=user)
 
     def _key(self, tile):
         x, y, z = tile.coord

--- a/docker/patch/redis.py
+++ b/docker/patch/redis.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 import datetime
-
+import os
 import hashlib
 import time
 
@@ -40,11 +40,14 @@ class RedisCache(TileCacheBase):
     def __init__(self, host, port, prefix, ttl=0, db=0):
         if redis is None:
             raise ImportError("Redis backend requires 'redis' package.")
-
+        
+        # temporary patch - should be auto support on mapproxy 2.0
+        user = os.environ.get('REDIS_USERNAME')
+        password = os.environ.get('REDIS_PASSWORD')
         self.prefix = prefix
         self.lock_cache_id = 'redis-' + hashlib.md5((host + str(port) + prefix + str(db)).encode('utf-8')).hexdigest()
         self.ttl = ttl
-        self.r = redis.StrictRedis(host=host, port=port, db=db)
+        self.r = redis.StrictRedis(host=host, port=port, db=db, password=password,username=user)
 
     def _key(self, tile):
         x, y, z = tile.coord

--- a/helm/templates/_tplValues.tpl
+++ b/helm/templates/_tplValues.tpl
@@ -56,3 +56,7 @@ Custom definitions
 {{- define "common.fs.merged" -}}
 {{- include "common.tplvalues.merge" ( dict "values" ( list .Values.storage.fs .Values.global.storage.fs ) "context" . ) }}
 {{- end -}}
+
+{{- define "common.redis.merged" -}}
+{{- include "common.tplvalues.merge" ( dict "values" ( list .Values.redis .Values.global.redis ) "context" . ) }}
+{{- end -}}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -29,4 +29,6 @@ data:
   MAPPROXY_API_URL: {{ .Values.env.mapproxy.mapproxyApiUrl | quote}}
   SEED_ATTEMPTS: {{ .Values.env.seedAttempts | quote}}
   SEED_CONCURRENCY: {{ .Values.env.seedConcurrency | quote}}
+  REDIS_PASSWORD: {{ .Values.env.redis.password | quote}}
+  REDIS_USERNAME: {{ .Values.env.redis.user | quote}}
 {{- end }}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -1,6 +1,8 @@
 {{- $tracingUrl := include "cache-seeder.tracingUrl" . -}}
 {{- $metricsUrl := include "cache-seeder.metricsUrl" . -}}
 {{- $configmapName := include "configmap.fullname" . }}
+{{- $redis := (include "common.redis.merged" .) | fromYaml }}
+
 {{- if .Values.enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -29,6 +31,8 @@ data:
   MAPPROXY_API_URL: {{ .Values.env.mapproxy.mapproxyApiUrl | quote}}
   SEED_ATTEMPTS: {{ .Values.env.seedAttempts | quote}}
   SEED_CONCURRENCY: {{ .Values.env.seedConcurrency | quote}}
-  REDIS_PASSWORD: {{ .Values.env.redis.password | quote}}
-  REDIS_USERNAME: {{ .Values.env.redis.user | quote}}
+  {{ if $redis.auth.enableRedisUser }}
+  REDIS_PASSWORD: {{ $redis.auth.password | quote}}
+  REDIS_USERNAME: {{ $redis.auth.username | quote}}
+  {{ end }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -11,6 +11,7 @@ global:
       internalPvc:
         name: ""
         tilesSubPath: ""
+  redis: {}
 
 storage: # local service level
   tilesStorageProvider: ""
@@ -24,6 +25,12 @@ storage: # local service level
       name: ""
       mountPath: ""
       tilesSubPath: ""
+
+redis: # same hierarchy as in mapproxy-api values
+  auth:
+    enableRedisUser: false
+    username: ""
+    password: ""
 
 secretName: ""
 enabled: true
@@ -93,9 +100,6 @@ env:
   metrics:
     enabled: false
     url: http://localhost:55681/v1/metrics
-  redis: 
-    user: ""
-    password: ""
   queue:
     jobManagerBaseUrl: "http://localhost:8081"
     heartbeat:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -93,6 +93,9 @@ env:
   metrics:
     enabled: false
     url: http://localhost:55681/v1/metrics
+  redis: 
+    user: ""
+    password: ""
   queue:
     jobManagerBaseUrl: "http://localhost:8081"
     heartbeat:

--- a/src/mapproxyUtils/mapproxySeed.ts
+++ b/src/mapproxyUtils/mapproxySeed.ts
@@ -311,7 +311,7 @@ export class MapproxySeed {
       const errMsg = seedLogStr.split('- ERROR -')[1];
       this.logger.error(errMsg);
       throw new Error(errMsg);
-    } else if (seedLogStr.match(/error in configuration:/)) {
+    } else if (seedLogStr.match(/error in configuration:/g)) {
       // substr that detect some mapproxy configuration errors
       this.logger.error(seedLogStr);
       throw new Error(seedLogStr);


### PR DESCRIPTION
Current mapproxy 1.16 default behave not support redis with auth.

Added redis.py patch to pass user pass if exists

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                       |
| New feature     | ✔                                                                       |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

On future will be default as we will move to mapproxy 2.0.x