### PR TITLE
fix: adapting helm for umbrella

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,6 +10,7 @@ global:
     fs:
       internalPvc:
         name: ""
+        mountPath: ""
         tilesSubPath: ""
   redis: {}
 


### PR DESCRIPTION


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                      |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔/✖                                                                       |

Making mountPath to fit the global scope of raster-helm