### PR TITLE
refactor: support global servicesUrl scope

### DIFF
--- a/helm/templates/_tplValues.tpl
+++ b/helm/templates/_tplValues.tpl
@@ -60,3 +60,7 @@ Custom definitions
 {{- define "common.redis.merged" -}}
 {{- include "common.tplvalues.merge" ( dict "values" ( list .Values.redis .Values.global.redis ) "context" . ) }}
 {{- end -}}
+
+{{- define "common.serviceUrls.merged" -}}
+{{- include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceUrls .Values.global.serviceUrls ) "context" . ) }}
+{{- end -}}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -2,6 +2,7 @@
 {{- $metricsUrl := include "cache-seeder.metricsUrl" . -}}
 {{- $configmapName := include "configmap.fullname" . }}
 {{- $redis := (include "common.redis.merged" .) | fromYaml }}
+{{- $serviceUrls := (include "common.serviceUrls.merged" .) | fromYaml }}
 
 {{- if .Values.enabled -}}
 apiVersion: v1
@@ -22,13 +23,13 @@ data:
   TELEMETRY_METRICS_URL: {{ $metricsUrl }}
   {{ end }}
   npm_config_cache: /tmp/
-  QUEUE_JOB_MANAGER_BASE_URL: {{ .Values.env.queue.jobManagerBaseUrl | quote}}
-  QUEUE_HEART_BEAT_MANAGER_BASE_URL: {{ .Values.env.queue.heartbeat.heartbeatManagerBaseUrl | quote}}
+  QUEUE_JOB_MANAGER_BASE_URL: {{ $serviceUrls.jobManager | quote}}
+  QUEUE_HEART_BEAT_MANAGER_BASE_URL: {{ $serviceUrls.heartbeatManager | quote}}
   QUEUE_HEART_BEAT_INTERVAL_MS: {{ .Values.env.queue.heartbeat.heartbeatIntervalMs | quote}}
   QUEUE_DEQUEUE_INTERVAL_MS: {{ .Values.env.queue.dequeueIntervalMs | quote}}
   QUEUE_JOB_TYPE: {{ .Values.env.queue.jobType | quote}}
   QUEUE_TASK_TYPE: {{ .Values.env.queue.tilesTaskType | quote}}
-  MAPPROXY_API_URL: {{ .Values.env.mapproxy.mapproxyApiUrl | quote}}
+  MAPPROXY_API_URL: {{ $serviceUrls.mapproxyApi | quote}}
   SEED_ATTEMPTS: {{ .Values.env.seedAttempts | quote}}
   SEED_CONCURRENCY: {{ .Values.env.seedConcurrency | quote}}
   {{ if $redis.auth.enableRedisUser }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -12,6 +12,10 @@ global:
         name: ""
         mountPath: ""
         tilesSubPath: ""
+  serviceUrls:
+    mapproxyApi: ""
+    jobManager: ""
+    heartbeatManager: ""
   redis: {}
 
 storage: # local service level
@@ -78,6 +82,11 @@ cloudProvider:
   imagePullSecretName: ''
   flavor: openshift
 
+serviceUrls:
+  mapproxyApi: ""
+  jobManager: ""
+  heartbeatManager: ""
+
 caSecretName: ''
 caPath: '/usr/local/share/ca-certificates'
 caKey: 'ca.crt'
@@ -102,15 +111,11 @@ env:
     enabled: false
     url: http://localhost:55681/v1/metrics
   queue:
-    jobManagerBaseUrl: "http://localhost:8081"
     heartbeat:
-      heartbeatManagerBaseUrl: "http://localhost:8089"
       heartbeatIntervalMs: 3000
     dequeueIntervalMs: 2000
     jobType: "TilesSeeding"
     tilesTaskType: "TilesSeeding"
-  mapproxy:
-    mapproxyApiUrl: "http://localhost:8083"
   seedAttempts: 5
   seedConcurrency: 5
 


### PR DESCRIPTION
Refactor - service urls should be injected from raster-helm servicesURl scope

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

