### PR TITLE
fix: insert timeout after polling valid job

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -65,5 +65,9 @@
   "seedConcurrency": {
     "__name": "SEED_CONCURRENCY",
     "__format": "number"
+  },
+  "gracefulReloadMaxSeconds": {
+    "__name": "GRACEFUL_RELOAD_MAX_SECONDS",
+    "__format": "number"
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -43,5 +43,6 @@
     "seedProgressFileDir": "/mapproxy/mapproxy_seed_progress"
   },
   "seedAttempts": 5,
-  "seedConcurrency": 5
+  "seedConcurrency": 5,
+  "gracefulReloadMaxSeconds": 300
 }

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -35,5 +35,6 @@ data:
   {{ if $redis.auth.enableRedisUser }}
   REDIS_PASSWORD: {{ $redis.auth.password | quote}}
   REDIS_USERNAME: {{ $redis.auth.username | quote}}
+  GRACEFUL_RELOAD_MAX_SECONDS: {{ .Values.global.gracefulReloadMaxSeconds | quote }}
   {{ end }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -17,6 +17,7 @@ global:
     jobManager: ""
     heartbeatManager: ""
   redis: {}
+  gracefulReloadMaxSeconds: 300
 
 storage: # local service level
   tilesStorageProvider: ""

--- a/tests/mocks/config.ts
+++ b/tests/mocks/config.ts
@@ -82,6 +82,7 @@ const registerDefaultConfig = (): void => {
       geometryTxtFile: '/mapproxy/coverage.json',
       seedProgressFileDir: '/mapproxy/mapproxy_seed_progress',
     },
+    gracefulReloadMaxSeconds: 0,
     seedAttempts: 5,
   };
   setConfigValues(config);


### PR DESCRIPTION
Insert configurable param for polling delay 

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Cache-seeder should poll job and wait X configurable time so the mapproxy actually will reload the configuration (gracefulReloadMaxSeconds)