### PR TITLE
fix: refresh time for seeder with bumping by factor

### DIFF
--- a/src/mapproxyUtils/mapproxySeed.ts
+++ b/src/mapproxyUtils/mapproxySeed.ts
@@ -102,7 +102,7 @@ export class MapproxySeed {
     );
     const utcDate = new Date(nowUtc);
     const validSeedDateFormatted = utcDate.toISOString().replace(/\..+/, '');
-    
+
     return validSeedDateFormatted;
   }
 

--- a/src/mapproxyUtils/mapproxySeed.ts
+++ b/src/mapproxyUtils/mapproxySeed.ts
@@ -21,6 +21,7 @@ export class MapproxySeed {
   private readonly geometryCoverageFilePath: string;
   private readonly seedConcurrency: number;
   private readonly mapproxySeedProgressDir: string;
+  private readonly gracefulReloadMaxSeconds: number;
 
   public constructor(
     @inject(SERVICES.LOGGER) private readonly logger: Logger,
@@ -32,9 +33,12 @@ export class MapproxySeed {
     this.geometryCoverageFilePath = this.config.get<string>('mapproxy.geometryTxtFile');
     this.seedConcurrency = 5;
     this.mapproxySeedProgressDir = this.config.get<string>('mapproxy.seedProgressFileDir');
+    this.gracefulReloadMaxSeconds = this.config.get<number>('gracefulReloadMaxSeconds');
   }
 
   public async runSeed(task: ISeed, jobId: string, taskId: string): Promise<void> {
+    task.refreshBefore = this.addTimeMinuteBuffer(task.refreshBefore);
+
     this.logger.info({
       msg: `processing ${task.mode} for job of ${task.layerId}`,
       jobId,
@@ -76,6 +80,28 @@ export class MapproxySeed {
       this.logger.error({ msg: `failed seed for job (type of ${task.mode}) of ${task.layerId}`, jobId, taskId, err });
       throw new Error(`failed seed for job of ${task.layerId} with reason: ${(err as Error).message}`);
     }
+  }
+
+  public addTimeMinuteBuffer(dataTimeStr: string): string {
+    const secondsInMin = 60;
+    const factor = 2;
+    const timeBufferMinute = (this.gracefulReloadMaxSeconds / secondsInMin) * factor;
+    const origDateTime = new Date(dataTimeStr);
+    const minutes = origDateTime.getMinutes() + timeBufferMinute;
+    const newDateTime = new Date(origDateTime.setMinutes(minutes));
+
+    const nowUtc = Date.UTC(
+      newDateTime.getFullYear(),
+      newDateTime.getMonth(),
+      newDateTime.getDate(),
+      newDateTime.getHours(),
+      newDateTime.getMinutes(),
+      newDateTime.getSeconds()
+    );
+    const utcDate = new Date(nowUtc);
+    const validSeedDateFormatted = utcDate.toISOString().replace(/\..+/, '');
+
+    return validSeedDateFormatted;
   }
 
   private async writeGeojsonTxtFile(path: string, data: string, jobId: string, taskId: string): Promise<void> {

--- a/src/mapproxyUtils/mapproxySeed.ts
+++ b/src/mapproxyUtils/mapproxySeed.ts
@@ -22,6 +22,8 @@ export class MapproxySeed {
   private readonly seedConcurrency: number;
   private readonly mapproxySeedProgressDir: string;
   private readonly gracefulReloadMaxSeconds: number;
+  private readonly secondsInMin: number;
+  private readonly bumpFactor: number;
 
   public constructor(
     @inject(SERVICES.LOGGER) private readonly logger: Logger,
@@ -34,6 +36,8 @@ export class MapproxySeed {
     this.seedConcurrency = 5;
     this.mapproxySeedProgressDir = this.config.get<string>('mapproxy.seedProgressFileDir');
     this.gracefulReloadMaxSeconds = this.config.get<number>('gracefulReloadMaxSeconds');
+    this.secondsInMin = 60;
+    this.bumpFactor = 2;
   }
 
   public async runSeed(task: ISeed, jobId: string, taskId: string): Promise<void> {
@@ -83,9 +87,7 @@ export class MapproxySeed {
   }
 
   public addTimeMinuteBuffer(dataTimeStr: string): string {
-    const secondsInMin = 60;
-    const factor = 2;
-    const timeBufferMinute = (this.gracefulReloadMaxSeconds / secondsInMin) * factor;
+    const timeBufferMinute = Math.max(this.gracefulReloadMaxSeconds / this.secondsInMin, 1) * this.bumpFactor;
     const origDateTime = new Date(dataTimeStr);
     const minutes = origDateTime.getMinutes() + timeBufferMinute;
     const newDateTime = new Date(origDateTime.setMinutes(minutes));
@@ -100,7 +102,7 @@ export class MapproxySeed {
     );
     const utcDate = new Date(nowUtc);
     const validSeedDateFormatted = utcDate.toISOString().replace(/\..+/, '');
-
+    
     return validSeedDateFormatted;
   }
 

--- a/tests/mockData/seedCleanYaml.yaml
+++ b/tests/mockData/seedCleanYaml.yaml
@@ -10,7 +10,7 @@ cleanups:
       from: 0
       to: 21
     remove_before:
-      time: '2025-01-16T16:14:22'
+      time: '2025-01-16T16:24:22'
 coverages:
   test-coverage:
     datasource: /mapproxy/coverage.json

--- a/tests/mockData/seedYaml.yaml
+++ b/tests/mockData/seedYaml.yaml
@@ -10,7 +10,7 @@ seeds:
       from: 0
       to: 21
     refresh_before:
-      time: '2025-01-16T16:14:22'
+      time: '2025-01-16T16:24:22'
 coverages:
   test-coverage:
     datasource: /mapproxy/coverage.json

--- a/tests/unit/mapproxyUtils/mapproxySeedFailures.spec.ts
+++ b/tests/unit/mapproxyUtils/mapproxySeedFailures.spec.ts
@@ -185,8 +185,9 @@ describe('#MapproxySeed', () => {
         const writeMapproxyYamlSpy = jest.spyOn(MapproxySeed.prototype as unknown as { writeMapproxyYaml: jest.Mock }, 'writeMapproxyYaml');
         const writeGeojsonTxtFileSpy = jest.spyOn(MapproxySeed.prototype as unknown as { writeGeojsonTxtFile: jest.Mock }, 'writeGeojsonTxtFile');
         const createSeedYamlFileSpy = jest.spyOn(MapproxySeed.prototype as unknown as { createSeedYamlFile: jest.Mock }, 'createSeedYamlFile');
+        const addTimeMinuteBufferSpy = jest.spyOn(MapproxySeed.prototype as unknown as { addTimeMinuteBuffer: jest.Mock }, 'addTimeMinuteBuffer');
         const executeSeedSpy = jest.spyOn(MapproxySeed.prototype as unknown as { executeSeed: jest.Mock }, 'executeSeed');
-
+        addTimeMinuteBufferSpy.mockImplementation((str) => str);
         const action = async () => {
           await mapproxySeed.runSeed({ ...task.parameters.seedTasks[0], refreshBefore: 'badDate' } as unknown as ISeed, task.jobId, task.id);
         };


### PR DESCRIPTION
While seed job waiting by delay for graceful reload, the refreshBefore time should also be bumped by this factor.

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |
