### PR TITLE
fix: seedConcurrency value from hard-coded to configuration

### DIFF
--- a/src/mapproxyUtils/mapproxySeed.ts
+++ b/src/mapproxyUtils/mapproxySeed.ts
@@ -280,7 +280,8 @@ export class MapproxySeed {
         flags.push('--skip-uncached');
       }
 
-      this.logger.info({msg: 'Execute cli command for seed' ,command: `mapproxy-seed ${flags}` })
+      /* eslint-disable @typescript-eslint/restrict-template-expressions */
+      this.logger.info({ msg: 'Execute cli command for seed', command: `mapproxy-seed ${flags}` });
       const cmd = $`mapproxy-seed ${flags}`;
       // promise wrap to synchronized zx internal events with node run time event
       await new Promise<void>((resolve, reject) => {

--- a/src/mapproxyUtils/mapproxySeed.ts
+++ b/src/mapproxyUtils/mapproxySeed.ts
@@ -33,7 +33,7 @@ export class MapproxySeed {
     this.mapproxyYamlDir = this.config.get<string>('mapproxy.mapproxyYamlDir');
     this.seedYamlDir = this.config.get<string>('mapproxy.seedYamlDir');
     this.geometryCoverageFilePath = this.config.get<string>('mapproxy.geometryTxtFile');
-    this.seedConcurrency = 5;
+    this.seedConcurrency = this.config.get<number>('seedConcurrency');
     this.mapproxySeedProgressDir = this.config.get<string>('mapproxy.seedProgressFileDir');
     this.gracefulReloadMaxSeconds = this.config.get<number>('gracefulReloadMaxSeconds');
     this.secondsInMin = 60;
@@ -280,6 +280,7 @@ export class MapproxySeed {
         flags.push('--skip-uncached');
       }
 
+      this.logger.info({msg: 'Execute cli command for seed' ,command: `mapproxy-seed ${flags}` })
       const cmd = $`mapproxy-seed ${flags}`;
       // promise wrap to synchronized zx internal events with node run time event
       await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
seedConcurrency should be taken value from config and not hard-coded

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |
