### PR TITLE
refactor: make ca-cert to global scope (MAPCO-4157)

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -62,10 +62,10 @@ spec:
           {{- end }}
           {{- end }}
           volumeMounts:
-            {{- if .Values.caSecretName }}
+            {{- if .Values.global.ca.caSecretName }}
             - name: root-ca
-              mountPath: {{ printf "%s/%s" .Values.caPath .Values.caKey | quote }}
-              subPath: {{ quote .Values.caKey }}
+              mountPath: {{ printf "%s/%s" .Values.global.ca.caPath .Values.global.ca.caKey | quote }}
+              subPath: {{ quote .Values.global.ca.caKey }}
             {{- end }}
             {{- if .Values.extraVolumeMounts -}}
               {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
@@ -78,11 +78,11 @@ spec:
           env:
             - name: SERVER_PORT
               value: {{ .Values.env.targetPort | quote }}
-            {{- if .Values.caSecretName }}
+            {{- if .Values.global.ca.caSecretName }}
             - name: REQUESTS_CA_BUNDLE
-              value: {{ printf "%s/%s" .Values.caPath .Values.caKey | quote }}
+              value: {{ printf "%s/%s" .Values.global.ca.caPath .Values.global.ca.caKey | quote }}
             - name: NODE_EXTRA_CA_CERTS
-              value: {{ printf "[%s/%s]" .Values.caPath .Values.caKey | quote }}
+              value: {{ printf "[%s/%s]" .Values.global.ca.caPath .Values.global.ca.caKey | quote }}
             {{- end }}
             {{- if eq (upper $storage.tilesStorageProvider) "S3" }}
             - name: AWS_ACCESS_KEY_ID
@@ -138,7 +138,7 @@ spec:
         {{- if .Values.caSecretName }}
         - name: root-ca
           secret:
-            secretName: {{ .Values.caSecretName }}
+            secretName: {{ .Values.global.ca.caSecretName }}
         {{- end }}
         {{- if eq (upper $storage.tilesStorageProvider) "FS" }}
         - name: output-storage

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -17,6 +17,10 @@ global:
     jobManager: ""
     heartbeatManager: ""
   redis: {}
+  ca:    
+    caSecretName: ''
+    caPath: '/usr/local/share/ca-certificates'
+    caKey: 'ca.crt'
   gracefulReloadMaxSeconds: 300
 
 storage: # local service level
@@ -88,10 +92,6 @@ serviceUrls:
   mapproxyApi: ""
   jobManager: ""
   heartbeatManager: ""
-
-caSecretName: ''
-caPath: '/usr/local/share/ca-certificates'
-caKey: 'ca.crt'
 
 tracing:
   enabled: false


### PR DESCRIPTION
Ca-root should be on global scope (like overseer + raster-helm)

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                      |
