### PR TITLE
fix: upgrade the git action to support workers CI's

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -4,5 +4,7 @@ on: [pull_request]
 
 jobs:
   pull_request:
-    uses: MapColonies/shared-workflows/.github/workflows/pull_request.yaml@workersTS
+    uses: MapColonies/shared-workflows/.github/workflows/pull_request.yaml@master
     secrets: inherit
+    with:
+      enableOpenApiCheck: false

--- a/.github/workflows/release-on-tag-push.yaml
+++ b/.github/workflows/release-on-tag-push.yaml
@@ -11,4 +11,3 @@ jobs:
     secrets: inherit
     with:
       enableOpenApiToPostman: false
- 

--- a/.github/workflows/release-on-tag-push.yaml
+++ b/.github/workflows/release-on-tag-push.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   release_on_tag_push:
-    uses: MapColonies/shared-workflows/.github/workflows/release-on-tag-push.yaml@workersTS
+    uses: MapColonies/shared-workflows/.github/workflows/release-on-tag-push.yaml@master
     secrets: inherit
+    with:
+      enableOpenApiToPostman: false
     

--- a/.github/workflows/release-on-tag-push.yaml
+++ b/.github/workflows/release-on-tag-push.yaml
@@ -11,5 +11,4 @@ jobs:
     secrets: inherit
     with:
       enableOpenApiToPostman: false
-
-    
+ 

--- a/.github/workflows/release-on-tag-push.yaml
+++ b/.github/workflows/release-on-tag-push.yaml
@@ -11,4 +11,5 @@ jobs:
     secrets: inherit
     with:
       enableOpenApiToPostman: false
+
     


### PR DESCRIPTION
Move back to master branch on shared-workflows and add right  flags to ignore openapi's + postman sections

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

