### PR TITLE
fix: removing max_old_space_size from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,5 @@ RUN chmod -R 777 /mapproxy
 
 USER node
 EXPOSE 8080
-CMD ["dumb-init", "node", "--max_old_space_size=512", "./index.js"]
+CMD ["dumb-init", "node",  "./index.js"]
 


### PR DESCRIPTION

| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✖      |
| New feature     | ✖      |
| Breaking change | ✖      |
| Deprecations    | ✖      |
| Documentation   | ✖      |
| Tests added     | ✖      |
| Chore           | ✔      |

