### PR TITLE
helm: added k8s pod uid env

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -77,6 +77,10 @@ spec:
               subPath: {{ $fs.internalPvc.tilesSubPath }}
             {{- end }}
           env:
+            - name: K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: SERVER_PORT
               value: {{ .Values.env.targetPort | quote }}
             {{- if .Values.global.ca.caSecretName }}


### PR DESCRIPTION
This pull request introduces a minor change to the Kubernetes deployment manifest by adding a new environment variable to the container specification. The new variable exposes the pod's unique identifier to the running application.

- **Deployment manifest update:**
  * Added the `K8S_POD_UID` environment variable to the container, sourcing its value from the pod's metadata UID. This allows the application to access its own Kubernetes pod UID at runtime.

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

