### PR TITLE
helm: fixed NODE_EXTRA_CA_CERTS ca path

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
             - name: REQUESTS_CA_BUNDLE
               value: {{ printf "%s/%s" .Values.global.ca.caPath .Values.global.ca.caKey | quote }}
             - name: NODE_EXTRA_CA_CERTS
-              value: {{ printf "[%s/%s]" .Values.global.ca.caPath .Values.global.ca.caKey | quote }}
+              value: {{ printf "%s/%s" .Values.global.ca.caPath .Values.global.ca.caKey | quote }}
             {{- end }}
             {{- if eq (upper $storage.tilesStorageProvider) "S3" }}
             - name: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
This pull request makes a small but important fix to the `helm/templates/deployment.yaml` file. It corrects the value assigned to the `NODE_EXTRA_CA_CERTS` environment variable, ensuring it matches the expected format.

- Fixed the formatting of the `NODE_EXTRA_CA_CERTS` environment variable by removing unnecessary square brackets, so it now matches the format used for `REQUESTS_CA_BUNDLE`.

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

